### PR TITLE
Add pip requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+cython~=0.29
+ecdsa~=0.16
+lxml~=4.6
+numpy~=1.20
+pillow~=8.2
+pyasn1==0.1.9
+pycrypto~=2.6
+pyserial~=3.5
+scipy~=1.6
+setuptools~=56.0

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -2,6 +2,7 @@
 from pkgutil import walk_packages
 from setuptools import Extension
 import subprocess
+import pathlib
 import platform
 import sys
 import os
@@ -83,8 +84,21 @@ def get_version():
 
 
 def get_install_requires():
-    return ['setuptools', 'pycrypto', 'pyserial', 'pillow', 'numpy', 'scipy',
-            'ecdsa', 'lxml', 'pyasn1==0.1.9']
+    """
+    Parses centralized dependencies from the requirements.txt file.
+
+    Because the requirements file is now the sole source of project
+    dependencies, OSError exceptions resulting from file access failure are
+    allowed halt execution.
+
+    Returns
+    -------
+    sequence
+        Strings containing dependencies and their version specifiers.
+
+    """
+    reqs_file_path = pathlib.Path('.', 'requirements.txt')
+    return reqs_file_path.read_text().split()
 
 
 def get_packages():


### PR DESCRIPTION
A requirements.txt file is a list of dependencies and version specifiers that is consumable by pip with `pip install -r requirements.txt`, easing the install process for end-users and developers.¹ To avoid having multiple places in which dependencies are listed, setuptools will now read dependencies from the requirements.txt file.

1. https://pip.pypa.io/en/stable/user_guide/#requirements-files 