### PR TITLE
Remove unused Cython method.

### DIFF
--- a/src/utils/utils.pyx
+++ b/src/utils/utils.pyx
@@ -167,9 +167,6 @@ cdef class GcodeToFcodeCpp:
         """
         return b'FC' + b'x0001' + b'\n'
 
-    cpdef extract_vector(self, obj):
-        cdef PathVector v = <PathVector> obj
-
     cpdef sub_convert_path(self):
         # self.path_js = FcodeBase.path_to_js(self.path)
         cdef FCode* fc = self.fc


### PR DESCRIPTION
Resolves #51. This particular method was causing a compilation error in generated C code. Given that this issue has remained unaddressed for several years, and that this method is never called, deleting it appears both safe and conducive to a cleaner codebase. Credit to @oscaracena for the fix.